### PR TITLE
fix: rename to CONTENTFUL_CMA_KEY

### DIFF
--- a/.github/workflows/act-repl.yml
+++ b/.github/workflows/act-repl.yml
@@ -18,7 +18,7 @@ jobs:
         id: act-repl
         uses: ./
         with:
-          contentManagementToken: ${{ secrets.CONTENFUL_CMA_KEY }}
+          contentManagementToken: ${{ secrets.CONTENTFUL_CMA_KEY }}
           typesenseAdminApiKey: ${{ secrets.TYPESENSE_ADMIN_API_KEY }}
           contentfulSpaceId: opxulaoc9o1m
           typesenseAction: dropAndCreateCollections

--- a/bin/index.js
+++ b/bin/index.js
@@ -34,7 +34,7 @@ program
   const require = createRequire(import.meta.url)
   const contentTypeMappings = require(resolve(process.cwd(), mappingsPath))
 
-  const managementToken = process.env.CONTENFUL_CMA_KEY
+  const managementToken = process.env.CONTENTFUL_CMA_KEY
   const spaceId = process.env.CONTENTFUL_SPACE_ID
 
   const contentfulClient = contentful.createClient({

--- a/example/bulkIndexer.js
+++ b/example/bulkIndexer.js
@@ -6,7 +6,7 @@ import Typesense from 'typesense'
 import { bulkIndexing } from '../src/lib/bulkIndexing.js'
 import { contentTypeMappings } from './contentTypeMappings.js'
 
-const managementToken = process.env.CONTENFUL_CMA_KEY
+const managementToken = process.env.CONTENTFUL_CMA_KEY
 
 const contentfulClient = contentful.createClient({
   accessToken: managementToken

--- a/example/runner.js
+++ b/example/runner.js
@@ -6,7 +6,7 @@ import sinon from 'sinon'
 import { run } from '../src/lib/run.js'
 import { contentTypeMappings } from './contentTypeMappings.js'
 
-const managementToken = process.env.CONTENFUL_CMA_KEY
+const managementToken = process.env.CONTENTFUL_CMA_KEY
 
 const contentfulClient = contentful.createClient({
   accessToken: managementToken

--- a/example/upserter.js
+++ b/example/upserter.js
@@ -5,7 +5,7 @@ import Typesense from 'typesense'
 import { upsertDocument } from '../src/lib/upsertDocument.js'
 import { contentTypeMappings } from './contentTypeMappings.js'
 
-const managementToken = process.env.CONTENFUL_CMA_KEY
+const managementToken = process.env.CONTENTFUL_CMA_KEY
 
 const contentfulClient = contentful.createClient({
   accessToken: managementToken


### PR DESCRIPTION
## Summary
- This is to rename the Contentful CMA access token from CONTENFUL_CMA_KEY to CONTENTFUL_CMA_KEY