### PR TITLE
Update default value for includeDrafts

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -27,7 +27,7 @@ program
     mappingsPath,
     environmentName,
     typesenseAction,
-    includeDrafts,
+    includeDrafts = false,
     locale
   } = options
 

--- a/src/lib/bulkIndexing.js
+++ b/src/lib/bulkIndexing.js
@@ -41,7 +41,7 @@ export const bulkIndexing = async ({
   managementToken,
   environmentName,
   contentTypeMappings,
-  includeDrafts = true,
+  includeDrafts,
   getContentfulExportData = getContentfulExportDataDefault,
   getContentfulEnvironment = getEnvironment
 }) => {


### PR DESCRIPTION
- remove `includeDrafts = true` from src/lib/bulkIndexing.js 
- add `includeDrafts = false` to bin/index.js